### PR TITLE
Don't revert Jira status if LP hasn't actually reverted

### DIFF
--- a/lp_to_jira_sync/lp_to_jira_sync.py
+++ b/lp_to_jira_sync/lp_to_jira_sync.py
@@ -1,6 +1,8 @@
 import argparse
 
 from lp_to_jira_sync.sync_config import SyncConfig
+from jira.resources import Issue
+from typing import Any
 
 
 jira_priorities_mapping = {'Unknown': 'Medium',
@@ -11,6 +13,7 @@ jira_priorities_mapping = {'Unknown': 'Medium',
                            'Low': 'Low',
                            'Wishlist': 'Lowest'}
 
+Bugset = tuple[int, str]
 
 # Create a Jira Entry from a LP bugset (list of tasks relevant to a bug and
 # package)
@@ -368,7 +371,7 @@ def sync(taskset, issue, config, log_msg = ""):
         config.jira.add_comment(issue, jira_comment)
 
 
-def process_issues(all_tasks, all_issues, config):
+def process_issues(all_tasks: dict[Bugset, list], all_issues: dict[Bugset, Issue], config):
     # Between All subscribed bug in LP and all bug imported in JIRA, there's
     # 3 Groups:
     #   A: bug are active in both LP and Jira

--- a/tests/test_lp_to_jira_sync.py
+++ b/tests/test_lp_to_jira_sync.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from io import StringIO
 from lp_to_jira_sync.lp_to_jira_sync import \
-    get_bug_id, get_bug_pkg
+    get_bug_id, get_bug_pkg, revert_jira_status
 
 
 def test_get_bug_id():
@@ -22,3 +22,29 @@ def test_get_bug_pkg():
     assert get_bug_pkg("LP#123234") == ""
     assert get_bug_pkg("LP#123234 [busybox] There is a problemm") == "busybox"
     assert get_bug_pkg("LP# 123234 [busybox] There is a problemm") == "busybox"
+
+def test_no_revert_while_in_sru_queue():
+    config = MagicMock(tag="bogus-tag", dry_run=False)
+    tasks = [
+            MagicMock(status="Fix Released"), # already fixed on devel series
+            MagicMock(status="In Progress"), # SRU in queue for last stable
+            MagicMock(status="Won't Fix"), # Not planning on fixing almost EOL interim release
+            MagicMock(status="In Progress"), # SRU in queue for last LTS
+            ]
+    issue = MagicMock(id="FR-1234")
+
+    revert_jira_status(config, issue, tasks)
+    config.jira.transition_issue.assert_not_called()
+
+def test_revert_bug_reopened():
+    config = MagicMock(tag="bogus-tag", dry_run=False)
+    tasks = [
+            MagicMock(status="Confirmed"), # Whoops, the devel fix didn't work!
+            MagicMock(status="In Progress"), # SRU in queue for last stable
+            MagicMock(status="Won't Fix"), # Not planning on fixing almost EOL interim release
+            MagicMock(status="In Progress"), # SRU in queue for last LTS
+            ]
+    issue = MagicMock(id="FR-1234")
+
+    revert_jira_status(config, issue, tasks)
+    config.jira.transition_issue.assert_called_with(issue, transition='Triaged')


### PR DESCRIPTION
There are some cases where the actual work will be done but the LP
status of the bug will not move, as the LP status has specific semantics
tied to a published package in the archive, and in some cases the work
will only be done in a Git repo but will wait for a later bulk upload to
be reflected in any published package.

For example, this frequently happens for systemd and glibc.

In addition, when working on an SRU, the uploaded package can be stuck
for a while in the SRU queue before publication, and can also sometimes
take a while before released into the release pocket.

Allowing a Jira issue to move to Done and stay there while the LP task
is still in one of those states makes working on those tasks much
easier, without having to remember to remove the relevant tag from the
issue.